### PR TITLE
QoL cross-platform change

### DIFF
--- a/image_generation/shaders/renderer_moderngl.py
+++ b/image_generation/shaders/renderer_moderngl.py
@@ -5,6 +5,7 @@ from image_generation.shaders.programs.twigl_program import *
 
 import multiprocessing as mp
 import os
+import platform
 from tqdm import tqdm
 
 import random
@@ -37,7 +38,9 @@ class RendererModernGL():
 
     self.resolution = resolution
     try:
-      self.ctx = moderngl.create_context(standalone=True, backend='egl', require=OPENGL_REQUIRED_VERSION, device_index=gpu)
+      # 'egl' is only available on Linux. otherwise, use the default backend instead
+      backend = dict(backend="egl") if platform.system() == "Linux" else dict()
+      self.ctx = moderngl.create_context(standalone=True, **backend, require=OPENGL_REQUIRED_VERSION, device_index=gpu)
       self.fbo = self.ctx.simple_framebuffer((self.resolution, self.resolution), components=4)
       self.fbo.use()
 
@@ -126,7 +129,7 @@ class RendererModernGL():
     elif type(self.temporal_sampling_mode) is list:
       timestep = self.temporal_sampling_mode[n_frame]
     else:
-      raise Exception("not impolemented")
+      raise Exception("not implemented")
 
     timestep_str = self.programs[program_i].get_timestep_uniform_str()
     self.update_uniform(program_i, timestep_str, timestep)


### PR DESCRIPTION
https://docs.python.org/3/library/platform.html
The code currently assumes by default you are running on linux. As far as I can tell, windows uses WGL and OSX uses GLX, neither supporting egl. This pull request is a slim change to check if you are in linux, and if you aren't use the default backend for your system as determined by modernGL.

I hadn't tested it other than on windows, and an even better solution might be to use the default backend regardless, but I figured it might save someone a headache. Take it or leave it ¯\_(ツ)_/¯.
Also, fixed a spelling error because it bugged me.